### PR TITLE
Issue 90

### DIFF
--- a/R/compose_stem_data.R
+++ b/R/compose_stem_data.R
@@ -23,6 +23,7 @@
 #'
 #' @importFrom rlang .data
 #' @importFrom dplyr %>% bind_rows filter inner_join mutate select
+#' @importFrom assertthat has_name
 #'
 compose_stem_data <- function(data_dendro, data_shoots) {
   #omit data that could be misinterpreted if data on shoot level are added
@@ -43,6 +44,30 @@ compose_stem_data <- function(data_dendro, data_shoots) {
       dbh_class_5cm = give_diamclass_5cm(.data$dbh_mm),
       basal_area_m2 = pi * (.data$dbh_mm / 2000) ^ 2
     )
+
+  if (
+    has_name(
+      stem_data,
+      c("iufro_hght", "iufro_vital", "iufro_socia", "iufro_hght_shoots",
+        "iufro_vital_shoots", "iufro_socia_shoots")
+    )
+  ) {
+    stem_data <- stem_data %>%
+      mutate(
+        iufro_hght =
+          ifelse(is.na(.data$iufro_hght_shoots),
+                 .data$iufro_hght, .data$iufro_hght_shoots),
+        iufro_hght_shoots = NULL,
+        iufro_vital =
+          ifelse(is.na(.data$iufro_vital_shoots),
+                 .data$iufro_vital, .data$iufro_vital_shoots),
+        iufro_vital_shoots = NULL,
+        iufro_socia =
+          ifelse(is.na(.data$iufro_socia_shoots),
+                 .data$iufro_socia, .data$iufro_socia_shoots),
+        iufro_socia_shoots = NULL
+      )
+  }
 
   return(stem_data)
 }

--- a/man/calculate_regeneration_plot.Rd
+++ b/man/calculate_regeneration_plot.Rd
@@ -10,7 +10,7 @@ calculate_regeneration_plot(data_regeneration)
 \item{data_regeneration}{dataframe on tree regeneration with variables ...}
 }
 \value{
-dataframe with columns plot/subplot, year and number_of_tree_species
+dataframe with columns plot, subplot, year and number_of_tree_species
 }
 \description{
 This function calculates for each plot and year the number of species, total number of trees and rubbing damage percentage for generation (for all height classes together).  For core area plots, these variables are calculated for each subplot.

--- a/man/calculate_regeneration_plot_height.Rd
+++ b/man/calculate_regeneration_plot_height.Rd
@@ -10,7 +10,7 @@ calculate_regeneration_plot_height(data_regeneration)
 \item{data_regeneration}{dataframe on tree regeneration with variables ...}
 }
 \value{
-dataframe with columns plot/subplot, year, height_class and number_of_tree_species
+dataframe with columns plot, subplot, year, height_class and number_of_tree_species
 }
 \description{
 This function calculates for each plot, tree height class and year the number of species, total number of trees and rubbing damage percentage for regeneration.  For core area plots, these variables are calculated for each subplot.

--- a/man/calculate_regeneration_plot_height_species.Rd
+++ b/man/calculate_regeneration_plot_height_species.Rd
@@ -10,7 +10,7 @@ calculate_regeneration_plot_height_species(data_regeneration)
 \item{data_regeneration}{dataframe on tree regeneration with variables ...}
 }
 \value{
-dataframe with columns plot/subplot, year, height_class, species and number_of_trees_ha
+dataframe with columns plot, subplot, year, height_class, species and number_of_trees_ha
 }
 \description{
 This function calculates for each plot, tree height class, species and year the number of trees and rubbing damage percentage per hectare for regeneration.  For core area plots, these variables are calculated for each subplot.

--- a/man/calculate_vegetation_plot.Rd
+++ b/man/calculate_vegetation_plot.Rd
@@ -12,7 +12,7 @@ calculate_vegetation_plot(data_vegetation, data_herblayer)
 \item{data_herblayer}{dataframe on vegetation in the species level ('herb layer') with variables ...}
 }
 \value{
-dataframe with columns plot/subplot, year (year of main vegetation survey, possible deviating year of spring survey not taken into account) and number_of_tree_species
+dataframe with columns plot, subplot, year (year of main vegetation survey, possible deviating year of spring survey not taken into account) and number_of_tree_species
 }
 \description{
 This function calculates for each plot (subplot in case of core area) and year the total coverage and the number of species in the vegetation layer. Year refers to year of the main vegetation survey (source is table "data_vegetation"), and will in some cases differ from the year of the spring flora survey.


### PR DESCRIPTION
In deze PR naar branch `reg_AL` zit de oplossing voor issue #90, die aanpassingen vraagt n.a.v. de iufro-klassen die pas in branch `reg_AL` toegevoegd zijn.  De oplossing bestaat erin dat de iufro-klassen bij elkaar gevoegd worden op voorwaarde dat alle 6 de variabelen (3 voor `data_dendro` en 3 voor `data_shoots`) in de dataset zitten.  Dus met ingeladen datasets waar niet mee geprutst wordt, loopt het goed, als de gebruiker beslist om bv. `iufro_socia` en `iufro_socia_shoots` te wissen voor het samenvoegen, worden de andere klassen ook niet samengevoegd.  Als hij `iufro_socia` niet nodig heeft, moet hij dit wissen na uitvoeren van `compose_stem_data()` (wat voor hem ook minder werk is dan vooraf in 2 datasets een variabele te wissen).

Ik weet niet of hierover iets expliciet in de documentatie vermeld moet worden?  Of evt. een extra vb. toevoegen met `extra_variables = TRUE` om te tonen dat dit ook kan?

(Bijkomend heb ik ook de documentatie geupdated, want dat was nog niet gebeurd n.a.v. enkele geaccepteerde suggesties.)