### PR TITLE
fix error in example

### DIFF
--- a/R/check_data_fmdb.R
+++ b/R/check_data_fmdb.R
@@ -27,7 +27,10 @@
 #'
 check_data_fmdb <- function(database, forest_reserve = "all") {
   incorrect_data <- check_data_trees(database, forest_reserve) %>%
-    mutate(layer = "Trees") %>%
+    mutate(
+      layer = "Trees",
+      aberrant_value = as.character(.data$aberrant_value)
+    ) %>%
     bind_rows(
       check_data_shoots(database, forest_reserve) %>%
         mutate(


### PR DESCRIPTION
Deze PR lost het foutje op dat de R CMD check geeft voor dat example.  (Probleem was dat een leeg record (NA) automatisch datatype logical krijgt, en dan wil `bind_rows()` nogal eens problemen geven.)  Misschien waren er wel properdere oplossingen te bedenken als deze, zoals dit probleem in de subfuncties ondervangen, maar ik heb het blijkbaar voor andere functies ook zo gedaan.